### PR TITLE
feat: open link in new page with meta/ctrl pressed

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -495,20 +495,22 @@ function handlePageTransition(to, from) {
   }
 }
 
+let isPressingMetaKey = false
+
 document.addEventListener('keydown', (event) => {
   if (event.metaKey || event.ctrlKey) {
-    document.documentElement.classList.add('pressing-meta-key')
+    isPressingMetaKey = true
   }
 })
 
 document.addEventListener('keyup', (event) => {
   if (!event.metaKey && !event.ctrlKey) {
-    document.documentElement.classList.remove('pressing-meta-key')
+    isPressingMetaKey = false
   }
 })
 
 router.beforeEach((to, from, next) => {
-  if (document.documentElement.classList.contains('pressing-meta-key')) {
+  if (isPressingMetaKey) {
     window.open(to.fullPath)
     return
   }


### PR DESCRIPTION
https://blog.matsu.io/stop-breaking-links-with-javascript

Changing all `$router.push` to `<RouterLink>` is not practical as there are lots of them.

This pull request adds the most common feature of opening links in new page with <kbd>Ctrl</kbd> (Windows) / <kbd>Command</kbd> (macOS) key pressed.